### PR TITLE
feat(loader): image dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev sqip-loader
 
 ## Usage
 
-The `sqip-loader` loads your image and exports the url of the image as `src` and the image/svg+xml URL-encoded data as `preview`. Additional `dimensions` object contains width, size and the type of imported image.
+The `sqip-loader` loads your image and exports the url of the image as `src` and the image/svg+xml URL-encoded data as `preview`. Additional `dimensions` object contains width, height and the type of imported image.
 
 ```js
 import { src, preview, dimensions } from './image.png';

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ npm install --save-dev sqip-loader
 
 ## Usage
 
-The `sqip-loader` loads your image and exports the url of the image as `src` and the image/svg+xml URL-encoded data as `preview`.
+The `sqip-loader` loads your image and exports the url of the image as `src` and the image/svg+xml URL-encoded data as `preview`. Additional `dimensions` object contains width, size and the type of imported image.
 
 ```js
-import { src, preview } from './image.png';
+import { src, preview, dimensions } from './image.png';
 ```
 
 **webpack.config.js**

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,8 +54,9 @@ module.exports = function(contentBuffer) {
     blur: blur
   });
   var encodedSvgDataUri = encodeSvgDataUri(sqipResult.final_svg);
-  
-  return 'module.exports = { "src": ' + src + ' , "preview": "' + encodedSvgDataUri + '" };';
+  var dimensions = JSON.stringify(sqipResult.img_dimensions)
+
+  return 'module.exports = { "src": ' + src + ' , "preview": "' + encodedSvgDataUri + '", "dimensions": ' + dimensions + ' };';
 };
 
 module.exports.raw = true;


### PR DESCRIPTION
Would be useful to utilize a full [sqip node api](https://github.com/technopagan/sqip#node-api) to get image dimensions.